### PR TITLE
ConnectionError

### DIFF
--- a/pytaboola/client.py
+++ b/pytaboola/client.py
@@ -2,7 +2,7 @@ import json
 import logging
 import requests
 import tenacity
-from requests.exceptions import ReadTimeout, ConnectTimeout
+from requests.exceptions import ReadTimeout, ConnectTimeout, ConnectionError
 
 from pytaboola.errors import Unauthorized
 from pytaboola.utils import parse_response
@@ -95,7 +95,7 @@ class TaboolaClient:
     @tenacity.retry(
         stop=tenacity.stop_after_attempt(6),
         wait=tenacity.wait_exponential(multiplier=1, exp_base=2),
-        retry=tenacity.retry_if_exception_type((ReadTimeout, ConnectTimeout)),
+        retry=tenacity.retry_if_exception_type((ReadTimeout, ConnectTimeout, ConnectionError)),
         before_sleep=tenacity.before_sleep_log(logger, logging.INFO),
     )
     def execute(self, method, uri, query_params=None,


### PR DESCRIPTION
# Summary

1. Taboola API started to show `OpenSSL.SSL.WantReadError`. Let's add `requests.exceptions.ConnectionError` to retry.

# Deployment Instructions

1. merge
2. add new release

3. change requirements.txt in OpenMail.